### PR TITLE
Add Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ The primary motivation is to make your Apple Health data accessible to AI coding
 
 ## Install
 
+### Homebrew
+
+```bash
+brew tap BRO3886/tap
+brew install healthsync
+```
+
+Or install via the install script:
+
 ```bash
 curl -fsSL https://healthsync.sidv.dev/install | bash
 ```


### PR DESCRIPTION
A Homebrew tap has been set up at BRO3886/tap, making healthsync installable via `brew tap BRO3886/tap && brew install healthsync`.

This adds a Homebrew subsection to the Install section in the README, placed first as the recommended install method ahead of the curl script, go install, and build from source options.
