### PR TITLE
Add Homebrew as primary install method on website

### DIFF
--- a/website/content/docs/getting-started.md
+++ b/website/content/docs/getting-started.md
@@ -10,7 +10,14 @@ toc: true
 
 ## Installation
 
-### Quick install (recommended)
+### Homebrew
+
+```bash
+brew tap BRO3886/tap
+brew install healthsync
+```
+
+### Quick install
 
 ```bash
 curl -fsSL https://healthsync.sidv.dev/install | bash

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -87,6 +87,11 @@
     <div class="home-section">
       <h2>Install</h2>
       <div class="install-block">
+        <span class="install-block-label">Homebrew (recommended)</span>
+        <pre><code>brew tap BRO3886/tap
+brew install healthsync</code></pre>
+      </div>
+      <div class="install-block">
         <span class="install-block-label">macOS / Linux</span>
         <pre><code>curl -fsSL https://healthsync.sidv.dev/install | bash</code></pre>
       </div>


### PR DESCRIPTION
Adds Homebrew as the first (recommended) install method in the Getting Started docs. Removed the "recommended" label from the curl install. Homebrew is now the preferred path for macOS users.
