### PR TITLE
Auto-update Homebrew formula on release

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,95 @@
+name: Update Homebrew formula
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-tap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for release assets
+        run: sleep 30
+
+      - name: Get release info
+        id: release
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download and checksum
+        id: checksums
+        run: |
+          DAR_ARM_URL="https://github.com/BRO3886/healthsync/releases/download/${{ github.ref_name }}/healthsync-darwin-arm64.tar.gz"
+          DAR_AMD_URL="https://github.com/BRO3886/healthsync/releases/download/${{ github.ref_name }}/healthsync-darwin-amd64.tar.gz"
+          LIN_ARM_URL="https://github.com/BRO3886/healthsync/releases/download/${{ github.ref_name }}/healthsync-linux-arm64.tar.gz"
+          LIN_AMD_URL="https://github.com/BRO3886/healthsync/releases/download/${{ github.ref_name }}/healthsync-linux-amd64.tar.gz"
+          curl -sL "$DAR_ARM_URL" -o dar_arm64.tar.gz
+          curl -sL "$DAR_AMD_URL" -o dar_amd64.tar.gz
+          curl -sL "$LIN_ARM_URL" -o lin_arm64.tar.gz
+          curl -sL "$LIN_AMD_URL" -o lin_amd64.tar.gz
+          echo "dar_arm64_sha=$(shasum -a 256 dar_arm64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          echo "dar_amd64_sha=$(shasum -a 256 dar_amd64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          echo "lin_arm64_sha=$(shasum -a 256 lin_arm64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          echo "lin_amd64_sha=$(shasum -a 256 lin_amd64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout tap
+        uses: actions/checkout@v4
+        with:
+          repository: BRO3886/homebrew-tap
+          token: ${{ secrets.TAP_GITHUB_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update formula
+        run: |
+          cat > homebrew-tap/Formula/healthsync.rb << 'FORMULA'
+          class Healthsync < Formula
+            desc "Parse Apple Health exports into a local SQLite database for AI agents and CLI queries"
+            homepage "https://github.com/BRO3886/healthsync"
+            version "${{ steps.release.outputs.version }}"
+            license "MIT"
+
+            on_macos do
+              on_arm do
+                url "https://github.com/BRO3886/healthsync/releases/download/${{ github.ref_name }}/healthsync-darwin-arm64.tar.gz"
+                sha256 "${{ steps.checksums.outputs.dar_arm64_sha }}"
+              end
+
+              on_intel do
+                url "https://github.com/BRO3886/healthsync/releases/download/${{ github.ref_name }}/healthsync-darwin-amd64.tar.gz"
+                sha256 "${{ steps.checksums.outputs.dar_amd64_sha }}"
+              end
+            end
+
+            on_linux do
+              on_arm do
+                url "https://github.com/BRO3886/healthsync/releases/download/${{ github.ref_name }}/healthsync-linux-arm64.tar.gz"
+                sha256 "${{ steps.checksums.outputs.lin_arm64_sha }}"
+              end
+
+              on_intel do
+                url "https://github.com/BRO3886/healthsync/releases/download/${{ github.ref_name }}/healthsync-linux-amd64.tar.gz"
+                sha256 "${{ steps.checksums.outputs.lin_amd64_sha }}"
+              end
+            end
+
+            def install
+              bin.install "healthsync"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/healthsync version")
+            end
+          end
+          FORMULA
+          sed -i 's/^          //' homebrew-tap/Formula/healthsync.rb
+
+      - name: Commit and push
+        run: |
+          cd homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/healthsync.rb
+          git diff --cached --quiet && echo "No changes" && exit 0
+          git commit -m "feat: bump healthsync to ${{ steps.release.outputs.version }}"
+          git push

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -42,34 +42,40 @@ jobs:
 
       - name: Update formula
         run: |
-          cat > homebrew-tap/Formula/healthsync.rb << 'FORMULA'
+          VERSION="${{ steps.release.outputs.version }}"
+          TAG="${{ github.ref_name }}"
+          DAR_ARM_SHA="${{ steps.checksums.outputs.dar_arm64_sha }}"
+          DAR_AMD_SHA="${{ steps.checksums.outputs.dar_amd64_sha }}"
+          LIN_ARM_SHA="${{ steps.checksums.outputs.lin_arm64_sha }}"
+          LIN_AMD_SHA="${{ steps.checksums.outputs.lin_amd64_sha }}"
+          cat > homebrew-tap/Formula/healthsync.rb <<EOF
           class Healthsync < Formula
             desc "Parse Apple Health exports into a local SQLite database for AI agents and CLI queries"
             homepage "https://github.com/BRO3886/healthsync"
-            version "${{ steps.release.outputs.version }}"
+            version "${VERSION}"
             license "MIT"
 
             on_macos do
               on_arm do
-                url "https://github.com/BRO3886/healthsync/releases/download/${{ github.ref_name }}/healthsync-darwin-arm64.tar.gz"
-                sha256 "${{ steps.checksums.outputs.dar_arm64_sha }}"
+                url "https://github.com/BRO3886/healthsync/releases/download/${TAG}/healthsync-darwin-arm64.tar.gz"
+                sha256 "${DAR_ARM_SHA}"
               end
 
               on_intel do
-                url "https://github.com/BRO3886/healthsync/releases/download/${{ github.ref_name }}/healthsync-darwin-amd64.tar.gz"
-                sha256 "${{ steps.checksums.outputs.dar_amd64_sha }}"
+                url "https://github.com/BRO3886/healthsync/releases/download/${TAG}/healthsync-darwin-amd64.tar.gz"
+                sha256 "${DAR_AMD_SHA}"
               end
             end
 
             on_linux do
               on_arm do
-                url "https://github.com/BRO3886/healthsync/releases/download/${{ github.ref_name }}/healthsync-linux-arm64.tar.gz"
-                sha256 "${{ steps.checksums.outputs.lin_arm64_sha }}"
+                url "https://github.com/BRO3886/healthsync/releases/download/${TAG}/healthsync-linux-arm64.tar.gz"
+                sha256 "${LIN_ARM_SHA}"
               end
 
               on_intel do
-                url "https://github.com/BRO3886/healthsync/releases/download/${{ github.ref_name }}/healthsync-linux-amd64.tar.gz"
-                sha256 "${{ steps.checksums.outputs.lin_amd64_sha }}"
+                url "https://github.com/BRO3886/healthsync/releases/download/${TAG}/healthsync-linux-amd64.tar.gz"
+                sha256 "${LIN_AMD_SHA}"
               end
             end
 
@@ -78,10 +84,10 @@ jobs:
             end
 
             test do
-              assert_match version.to_s, shell_output("#{bin}/healthsync version")
+              assert_match version.to_s, shell_output("\#{bin}/healthsync version")
             end
           end
-          FORMULA
+          EOF
           sed -i 's/^          //' homebrew-tap/Formula/healthsync.rb
 
       - name: Commit and push


### PR DESCRIPTION
Adds a GitHub Actions workflow that triggers on release publish events. It downloads the darwin/linux arm64/amd64 tarballs, computes SHA256 checksums, then checks out BRO3886/homebrew-tap and rewrites `Formula/healthsync.rb` with the new version and checksums.

Requires a `TAP_GITHUB_TOKEN` secret in this repo with write access to BRO3886/homebrew-tap.
