### PR TITLE
Update docs for v0.5.1 changes (timestamps, sleep totals, localized zips)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,8 @@ go test ./... -coverprofile=coverage.out && go tool cover -func=coverage.out
 - Category types (sleep, mindful_sessions, stand_hours) are `HKCategoryType` (no unit attribute) — `RecordColumns()` returns 4 columns, not 5; value stored as TEXT
 - Parser uses per-table `map[string][][]any` batch buffers — each table flushes at 1000 rows; all flush at EOF
 - Blood pressure staging: systolic + diastolic keyed by `{sourceName, startDate}`; row emitted only when both are staged; unpaired records silently dropped
+- Zip parsing is filename-agnostic: `findHealthExport` sniffs the first 32 KiB of each `.xml` entry for `<HealthData ` (trailing space guards against `<HealthDataArchive`). Handles localized filenames (e.g. `导出.xml` on Chinese-locale devices) without hardcoded locale lists. CDA sibling (`export_cda.xml`) is rejected naturally because its root is `<ClinicalDocument>`.
+- Timestamps are normalized at parse time: `normalizeTimestamp` strips the trailing ` ±HHMM` offset so stored values are plain `YYYY-MM-DD HH:MM:SS` local time. Applied to all date fields (Record start/end, Workout start/end, blood pressure staging key). SQLite date funcs (`julianday`, `date`) cannot parse the space-separated offset format, so this is required for `--total` aggregations to work.
 
 ### SQLite
 - WAL mode enabled for concurrent reads during server mode
@@ -54,7 +56,8 @@ go test ./... -coverprofile=coverage.out && go tool cover -func=coverage.out
 ### Query
 - `TableNameMap` maps both hyphen and underscore CLI names to DB table names (60+ entries)
 - `--format table|json|csv` — CSV/JSON use `sortedKeys()` for deterministic column order
-- `--total` routes to dedicated daily-total methods (NOT `QueryRows`) with overlap dedup
+- `--total` routes to dedicated daily-total methods (NOT `QueryRows`) with overlap dedup. Supported: `steps`, `active-energy`, `basal-energy`, `sleep`
+- `sleep --total` uses `date(start_date, '-6 hours')` to group by sleep night (pre-midnight sessions attributed to the correct night); filters `value LIKE '%Asleep%'` to exclude InBed and Awake; `--to` filter also gates on the shifted night date, not raw `start_date`
 - Source-priority deduplication: Watch=2 > iPhone=1 > other=0 (uses `strings.Contains` on sourceName)
 
 ### Server
@@ -86,6 +89,8 @@ go test ./... -coverprofile=coverage.out && go tool cover -func=coverage.out
 - Tests use `testing/fstest.MapFS` as fake embedded FS (no real files needed)
 
 ## Latest Release
+- v0.5.1 (unreleased, on main) — strip tz offsets from stored timestamps, `sleep --total` with 6h night shift, localized zip support (Chinese etc. via content sniffing)
+- v0.5.0 — `db info` subcommand, background update checker, OpenClaw skills target
 - v0.4.0 — 40+ Apple Health metrics, multi-format query output (table/json/csv), --total flag
 - v0.3.0 — skills install/uninstall/status command; 6 platform archives
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ healthsync parse export.zip
 healthsync parse export.zip -v  # verbose logging
 ```
 
-Accepts `.zip` (auto-extracts `export.xml`) or raw `.xml` files.
+Accepts `.zip` or raw `.xml` files. Inside a zip, the HealthKit XML is identified by content, so exports from non-English devices (e.g. `导出.xml` on Chinese) work without renaming.
 
 ### Query data
 
@@ -64,11 +64,12 @@ healthsync query body-mass --limit 30
 
 Output formats: `table` (default), `json`, `csv`
 
-Use `--total` with `steps`, `active-energy`, or `basal-energy` for deduplicated daily totals:
+Use `--total` with `steps`, `active-energy`, `basal-energy`, or `sleep` for deduplicated daily (or nightly) totals:
 
 ```bash
 healthsync query steps --total --from 2024-01-01
 healthsync query active-energy --total --from 2024-01-01
+healthsync query sleep --total --from 2024-01-01   # nightly sleep duration, hours
 ```
 
 ### AI agent skills

--- a/cmd/skills/healthsync/SKILL.md
+++ b/cmd/skills/healthsync/SKILL.md
@@ -181,6 +181,8 @@ sqlite3 ~/.healthsync/healthsync.db "SELECT strftime('%Y-W%W', start_date) as we
 
 Parse an Apple Health export into the database. (Informational — do not run unless the user asks.)
 
+Accepts `.zip` or `.xml`. Zip parsing identifies the HealthKit XML by content, not filename, so exports from any device locale work (e.g. `导出.xml` on Chinese).
+
 | Flag | Description | Default |
 |------|-------------|---------|
 | `-v` | Verbose logging with progress rate | false |
@@ -384,7 +386,7 @@ GROUP BY week ORDER BY week DESC LIMIT 12;
 
 - **Read-only** — This skill must never write to the database
 - **No real-time data** — Data is only as fresh as the last `healthsync parse` run
-- **Date filtering is string-based** — Timezone offsets are part of the stored date string
+- **Date filtering is string-based** — dates are stored as `YYYY-MM-DD HH:MM:SS` with no timezone offset; SQLite date functions (`date()`, `julianday()`, etc.) work directly on them
 - **SpO2 values are fractions** — 0.98 means 98%, not 98
 - **Blood pressure is paired** — systolic and diastolic are stored together in one row per measurement
 - **Category tables have no unit column** — `sleep`, `mindful_sessions`, `stand_hours` store text values, not numeric

--- a/website/content/docs/cli-reference.md
+++ b/website/content/docs/cli-reference.md
@@ -35,7 +35,7 @@ healthsync parse export.zip -v --db ./test.db
 ```
 
 **Behavior:**
-- Accepts `.zip` (auto-extracts `export.xml`) or raw `.xml`
+- Accepts `.zip` or raw `.xml`. Inside a zip, the HealthKit XML is identified by content (looking for `<HealthData`), so exports from any locale work — including non-English exports where the file is named e.g. `导出.xml`
 - Streams XML with constant memory (~10MB for 950MB files)
 - Uses `INSERT OR IGNORE` for deduplication — safe to re-run
 - Inserts in batches of 1000 rows per transaction

--- a/website/content/docs/getting-started.md
+++ b/website/content/docs/getting-started.md
@@ -72,7 +72,7 @@ healthsync parse export.zip
 ```
 
 This will:
-- Extract `export.xml` from the zip
+- Find the HealthKit XML inside the zip by content, so exports from non-English devices (e.g. `导出.xml` on Chinese) work without renaming
 - Stream-parse ~500k+ records in constant memory
 - Store data in `~/.healthsync/healthsync.db`
 - Deduplicate on re-import (safe to run weekly)

--- a/website/content/docs/schema.md
+++ b/website/content/docs/schema.md
@@ -313,7 +313,7 @@ All dates are stored as text in local time (timezone offset stripped during pars
 
 This format is compatible with SQLite's `date()`, `julianday()`, and other date functions. When filtering with `--from` / `--to`, use date prefixes — SQLite does string comparison, so `2024-01-01` matches all timestamps on that day.
 
-> **Note:** If you have an existing database from a pre-v0.5.0 parse, re-run `healthsync parse` on your export to get normalized timestamps. Old-format timestamps with timezone offsets (e.g. `+0530`) cause `julianday()` to return NULL.
+> **Note:** Databases parsed before v0.5.1 store timestamps with the timezone offset appended (e.g. `2024-01-15 08:30:00 +0530`), which causes `julianday()` and `date()` to return NULL. Re-run `healthsync parse` on your export to get normalized timestamps.
 
 ## Useful queries
 


### PR DESCRIPTION
## Summary

Propagates the user-visible changes from the two fix PRs that landed on main into every documentation surface:

- **PR #7** (sleep/timestamps): timestamps now stored without tz offset, `sleep --total` supported with 6-hour night shift
- **PR #11** (localized zip): zip parsing identifies the HealthKit XML by content, so non-English exports (e.g. `导出.xml` on Chinese) work without renaming

## Files updated

- `README.md` — zip locale-agnostic note, `sleep` added to the `--total` list with an example
- `CLAUDE.md` — XML parsing section now covers `findHealthExport` content sniffing and `normalizeTimestamp`; Query section covers `sleep --total` with night-shift and `--to` gating; "Latest Release" bumped with v0.5.1 notes
- `cmd/skills/healthsync/SKILL.md` — parse command now documents locale-agnostic zip support; Limitations section corrected (used to claim timezone offsets are part of the stored string — no longer true)
- `website/content/docs/getting-started.md` — zip extraction bullet now mentions locale support
- `website/content/docs/cli-reference.md` — parse behavior bullet rewritten to describe content sniffing
- `website/content/docs/schema.md` — migration note pinned to v0.5.1 (was incorrectly pinned to v0.5.0)

## Verification

- `go build ./...` passes
- 21 cmd+skills tests pass (embedded SKILL.md still valid)
- `hugo` renders the website cleanly (no warnings)
