### PR TITLE
Lengthen short meta descriptions flagged by Bing Webmaster

### DIFF
--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "healthsync"
-description: "Your Apple Health data, locally stored and queryable by AI agents. Parse exports into SQLite."
+description: "healthsync parses your Apple Health export into a SQLite database you can query via the CLI, serve over HTTP, or hand to an AI agent. Your data stays on-device."
 lead: "Parse Apple Health exports into a local SQLite database. Query from the CLI, serve over HTTP, or let your AI agent ask the questions."
 date: 2026-02-12T00:00:00+05:30
 lastmod: 2026-02-28T00:00:00+05:30

--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Documentation"
-description: "healthsync documentation"
+description: "Documentation for healthsync: install the CLI, parse an Apple Health export into SQLite, query your metrics, run the HTTP server, and connect an AI agent skill."
 date: 2026-02-12T00:00:00+05:30
 draft: false
 weight: 999

--- a/website/content/docs/agent-skills.md
+++ b/website/content/docs/agent-skills.md
@@ -1,6 +1,6 @@
 ---
 title: "Agent Skills"
-description: "Let your AI coding agent query your Apple Health data directly."
+description: "Install the healthsync agent skill so your AI coding agent can answer health questions directly, running CLI and SQL queries against your local database."
 date: 2026-02-25T00:00:00+05:30
 lastmod: 2026-02-28T00:00:00+05:30
 draft: false

--- a/website/content/docs/getting-started.md
+++ b/website/content/docs/getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: "Getting Started"
-description: "Install healthsync and parse your first Apple Health export."
+description: "Install healthsync via Homebrew or Go, then parse your first Apple Health export into a local SQLite database and run your first queries from the command line."
 date: 2026-02-12T00:00:00+05:30
 lastmod: 2026-02-28T00:00:00+05:30
 draft: false

--- a/website/content/docs/metrics.md
+++ b/website/content/docs/metrics.md
@@ -1,6 +1,6 @@
 ---
 title: "Supported Metrics"
-description: "What Apple Health data healthsync parses, and what's available for future support."
+description: "The Apple Health metrics healthsync parses into SQLite, from heart rate, sleep, and workouts to energy and body metrics, plus what's planned for future support."
 date: 2026-02-12T00:00:00+05:30
 lastmod: 2026-02-28T00:00:00+05:30
 draft: false

--- a/website/content/docs/schema.md
+++ b/website/content/docs/schema.md
@@ -1,6 +1,6 @@
 ---
 title: "Database Schema"
-description: "SQLite table definitions and query examples."
+description: "The healthsync SQLite schema: table definitions for every parsed Apple Health metric, where the database lives, and example queries you can run with sqlite3."
 date: 2026-02-12T00:00:00+05:30
 lastmod: 2026-02-28T00:00:00+05:30
 draft: false

--- a/website/content/docs/server-api.md
+++ b/website/content/docs/server-api.md
@@ -1,6 +1,6 @@
 ---
 title: "Server API"
-description: "HTTP API reference for the healthsync server."
+description: "HTTP API reference for the healthsync server: start it on any port, upload an Apple Health export, and query your parsed health metrics through JSON endpoints."
 date: 2026-02-12T00:00:00+05:30
 lastmod: 2026-02-28T00:00:00+05:30
 draft: false


### PR DESCRIPTION
Bing Webmaster flagged seven healthsync.sidv.dev pages for meta descriptions below the recommended length (the docs index was as short as 24 characters). This rewrites each page's frontmatter `description` to a unique, page-specific summary of 150 to 160 characters.

Pages fixed (rendered length in built HTML):
- `/` — 160
- `/docs/` — 160
- `/docs/getting-started/` — 159
- `/docs/server-api/` — 159
- `/docs/agent-skills/` — 153
- `/docs/metrics/` — 160
- `/docs/schema/` — 157

Verified by building the Hugo site (`hugo --minify`) and reading the rendered `<meta name="description">` in `website/public/**`. Source-only change to markdown frontmatter; no template or config changes.
