### PR TITLE
Group sleep totals by session instead of a fixed hour boundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ go test ./... -coverprofile=coverage.out && go tool cover -func=coverage.out
 - `TableNameMap` maps both hyphen and underscore CLI names to DB table names (60+ entries)
 - `--format table|json|csv` — CSV/JSON use `sortedKeys()` for deterministic column order
 - `--total` routes to dedicated daily-total methods (NOT `QueryRows`) with overlap dedup. Supported: `steps`, `active-energy`, `basal-energy`, `sleep`
-- `sleep --total` uses `date(start_date, '-6 hours')` to group by sleep night (pre-midnight sessions attributed to the correct night); filters `value LIKE '%Asleep%'` to exclude InBed and Awake; `--to` filter also gates on the shifted night date, not raw `start_date`
+- `sleep --total` groups by **session**, not by a clock boundary. Segments are clustered into sessions by breaking on gaps > 2h, then each whole session is assigned one night from its onset (`onset - 12h`). An earlier version bucketed on `date(start_date, '-6 hours')`, which put the night boundary at 06:00 and tore any night that ran past 6 AM in half — see #17. Any fixed hour bisects someone's sleep, so no fixed hour is used. Overlapping segments are merged before summing. Naps (daytime onset AND under 4h) go in their own column and never inflate `hours`. **Nights with no records are omitted, never reported as zero** — "did not sleep" and "did not wear the watch" are different facts. Filters `value LIKE '%Asleep%'` to exclude InBed and Awake; both `--from` and `--to` gate on the computed night
 - Source-priority deduplication: Watch=2 > iPhone=1 > other=0 (uses `strings.Contains` on sourceName)
 
 ### Server
@@ -89,7 +89,9 @@ go test ./... -coverprofile=coverage.out && go tool cover -func=coverage.out
 - Tests use `testing/fstest.MapFS` as fake embedded FS (no real files needed)
 
 ## Latest Release
-- v0.5.1 (unreleased, on main) — strip tz offsets from stored timestamps, `sleep --total` with 6h night shift, localized zip support (Chinese etc. via content sniffing)
+- v0.5.3 — `sleep --total` grouped by session instead of a fixed hour boundary (#17): a night running past 6 AM was split across two dates, fabricating hours for unworn nights and undercounting real ones. Adds `naps`, `onset`, `wake` columns; omits nights with no data
+- v0.5.2 — date parsing fixes
+- v0.5.1 — strip tz offsets from stored timestamps, `sleep --total` with 6h night shift, localized zip support (Chinese etc. via content sniffing)
 - v0.5.0 — `db info` subcommand, background update checker, OpenClaw skills target
 - v0.4.0 — 40+ Apple Health metrics, multi-format query output (table/json/csv), --total flag
 - v0.3.0 — skills install/uninstall/status command; 6 platform archives

--- a/cmd/skills/healthsync/SKILL.md
+++ b/cmd/skills/healthsync/SKILL.md
@@ -3,7 +3,7 @@ name: healthsync
 description: Queries Apple Health data stored in a local SQLite database. Use this skill to read heart rate, steps, SpO2, VO2 Max, sleep, workouts, resting heart rate, HRV, blood pressure, active/basal energy, body metrics, mobility, running metrics, mindful sessions, wrist temperature, and more. Can query via the healthsync CLI or directly via SQLite. Read-only — never write to the database.
 metadata:
   author: sidv
-  version: "1.1"
+  version: "1.2"
 compatibility: Requires healthsync binary. Database at ~/.healthsync/healthsync.db must be populated via `healthsync parse`.
 ---
 
@@ -43,6 +43,20 @@ Query Apple Health export data stored in a local SQLite database. This skill is 
 - **READ ONLY** — You must NEVER write to the database. No INSERT, UPDATE, DELETE, DROP, ALTER, or any write operations.
 - **Two query methods**: CLI (`healthsync query`) or direct SQLite (`sqlite3 ~/.healthsync/healthsync.db`)
 - **Prefer CLI** for simple queries. Use direct SQLite for complex aggregations, joins, or custom SQL.
+
+## Gotchas
+
+Read these before you report any number to a user. Each one has produced a confidently wrong answer.
+
+- **Steps and energy MUST use `--total`.** The raw table holds one row per source, so iPhone and Watch both record the same walk. A plain `SUM(value)` roughly doubles the real figure. `--total` deduplicates by source priority (Watch > iPhone > other).
+
+- **Never group sleep by night in your own SQL.** There is no correct hour to split on. Any `GROUP BY date(start_date, ...)` puts the night boundary at some fixed hour, and that hour lands in the middle of somebody's sleep — a user still asleep at 6 AM gets one night cut in half and filed under two dates. This is not hypothetical: it shipped as issue #17 and it fabricated hours for nights the watch was never worn while undercounting the real ones. Use `healthsync query sleep --total`, which clusters segments into whole sessions before assigning a date. If you must touch the raw table, select the segments and reason about sessions yourself; do not aggregate by date.
+
+- **A missing night means the watch was not worn. It does not mean zero sleep.** `sleep --total` omits nights with no data rather than emitting a zero row. If you average, average over the nights actually present and **state the denominator** ("5.9h across the 4 nights recorded"). An average that silently skips gaps, or one that treats a gap as a zero, is how a data gap becomes a false conclusion about a person's health.
+
+- **Naps are separate from night sleep.** `sleep --total` reports them in their own `naps` column and never folds them into `hours`. Do not add the two together and call it "sleep" — a 6.5h night plus a 1.7h nap is not an 8.2h night, and the question being asked is almost always about the nights.
+
+- **Sanity-check any health number against the person before reporting it.** If the data says someone slept 4 hours a night for a week straight, the far more likely explanation is a tool bug or a data gap than a person who did that and functioned. Reconcile the number with the raw rows before you build a conclusion on it.
 
 ## Database Location
 
@@ -301,6 +315,16 @@ healthsync query active-energy --total --from 2024-01-01
 ```bash
 healthsync query sleep --total --from 2024-01-01
 ```
+
+Returns one row per night that has data. See **Gotchas** for how to read it without drawing a false conclusion.
+
+| Column | Meaning |
+|--------|---------|
+| `night` | The date the night began. A session starting at 02:00 on the 5th belongs to the night of the 4th. |
+| `hours` | Night sleep only, Asleep stages only (InBed and Awake excluded, so this is time asleep, not time in bed). Empty if no night sleep was recorded. |
+| `naps`  | Daytime sleep, attributed to the night before it. Never included in `hours`. |
+| `onset` | When sleep began. This is what exposes a chronically late bedtime. |
+| `wake`  | When it ended. |
 
 ### Average resting heart rate per week
 ```sql

--- a/cmd/skills/healthsync/references/schema.md
+++ b/cmd/skills/healthsync/references/schema.md
@@ -787,18 +787,27 @@ LIMIT 30;
 
 ### Sleep duration per night (asleep only)
 
-Via CLI: `healthsync query sleep --total --from 2024-01-01`
+**Use the CLI for this. Do not hand-roll it in SQL.**
 
-Or via SQL (note the `-6 hours` shift for correct night grouping):
+```bash
+healthsync query sleep --total --from 2024-01-01
+```
+
+Grouping sleep by night is not a `GROUP BY date(...)`, and every attempt to write it as one is wrong. Any expression that buckets segments by a shifted calendar date puts the night boundary at some fixed hour, and whatever hour you choose will fall in the middle of somebody's night: pick 06:00 and you cut a late sleeper's sleep in half, filing the two halves under two different dates. That produces plausible-looking hours for nights that have no data at all, and undercounts the nights that do. It is not a hypothetical — it shipped, and it is issue #17.
+
+Correct nightly grouping requires clustering the segments into sessions first (break wherever the data goes quiet for more than ~2h), merging any overlapping segments, and only then assigning one date to each whole session. That is what `--total` does. Reproducing it in raw SQL is not worth it.
+
+If you must go to the raw table, query the **segments** and reason about sessions yourself — do not aggregate by date:
+
 ```sql
-SELECT date(start_date, '-6 hours') as night,
-       ROUND(SUM((julianday(end_date) - julianday(start_date)) * 24), 1) as hours
+SELECT start_date, end_date, value
 FROM sleep
 WHERE value LIKE '%Asleep%'
-GROUP BY night
-ORDER BY night DESC
-LIMIT 14;
+  AND start_date >= '2024-01-01'
+ORDER BY start_date ASC;
 ```
+
+Two things to hold onto when you interpret the result: a night with no rows means the watch was not worn, **not** that the user did not sleep, and daytime naps are separate sessions that should not be added into a night's total.
 
 ### Workout summary by type
 

--- a/internal/storage/queries.go
+++ b/internal/storage/queries.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // TableInfo holds per-table stats for db info output.
@@ -493,15 +494,114 @@ func (db *DB) queryEnergyDailyTotal(tableName string, params QueryParams) ([]map
 	return results, nil
 }
 
-// QuerySleepDailyTotal returns nightly sleep duration totals grouped by sleep night.
-// It shifts timestamps back 6 hours so that sessions starting in the evening (e.g. 23:00)
-// are attributed to the next calendar day's "sleep night". Only counts Asleep stages
-// (Core, Deep, REM, Unspecified), excluding InBed and Awake.
+const (
+	// sleepTimeLayout is the normalized form the parser writes to the sleep table.
+	sleepTimeLayout = "2006-01-02 15:04:05"
+
+	// sleepSessionGap is the idle time that separates two distinct sleep sessions.
+	// Awake segments inside a single night run to minutes; the gap between waking
+	// and a daytime nap runs to hours.
+	sleepSessionGap = 2 * time.Hour
+
+	// napOnsetStart and napOnsetEnd bound the hours in which an onset is treated as
+	// a nap rather than the start of a night. Onset time, not duration, decides this:
+	// a 2-hour night before an early flight is still a night, and a 3-hour Sunday
+	// afternoon collapse is still a nap.
+	napOnsetStart = 11
+	napOnsetEnd   = 20
+
+	// nightShift maps an onset to the night it belongs to. Any onset from noon
+	// onwards keeps its own date; any onset before noon rolls back to the previous
+	// date. This holds across the full plausible range of human bedtimes.
+	nightShift = 12 * time.Hour
+)
+
+// sleepSession is one contiguous run of Asleep segments, i.e. a real night or a
+// real nap, reconstructed from the gaps in the data rather than from the clock.
+type sleepSession struct {
+	start  time.Time
+	end    time.Time
+	asleep time.Duration
+}
+
+// isNap reports whether the session began during the hours in which a person is
+// awake, which makes it a nap rather than a night.
+func (s sleepSession) isNap() bool {
+	h := s.start.Hour()
+	return h >= napOnsetStart && h < napOnsetEnd
+}
+
+// night returns the date of the night this session belongs to. A nap is attributed
+// to the night that preceded it, so a night and the naps that follow it during the
+// same waking day land on one row.
+func (s sleepSession) night() string {
+	if s.isNap() {
+		return s.start.AddDate(0, 0, -1).Format(time.DateOnly)
+	}
+	return s.start.Add(-nightShift).Format(time.DateOnly)
+}
+
+// buildSleepSessions clusters time-ordered Asleep segments into sessions, breaking
+// wherever the data goes quiet for longer than sleepSessionGap. Overlapping segments
+// are merged before their durations are summed, so a stage recorded twice by two
+// sources is counted once.
+func buildSleepSessions(segments []sleepSession) []sleepSession {
+	var sessions []sleepSession
+	var cur []sleepSession
+
+	flush := func() {
+		if len(cur) == 0 {
+			return
+		}
+		merged := []sleepSession{cur[0]}
+		for _, seg := range cur[1:] {
+			last := &merged[len(merged)-1]
+			if !seg.start.After(last.end) {
+				if seg.end.After(last.end) {
+					last.end = seg.end
+				}
+				continue
+			}
+			merged = append(merged, seg)
+		}
+
+		var asleep time.Duration
+		for _, m := range merged {
+			asleep += m.end.Sub(m.start)
+		}
+		sessions = append(sessions, sleepSession{
+			start:  cur[0].start,
+			end:    cur[len(cur)-1].end,
+			asleep: asleep,
+		})
+		cur = nil
+	}
+
+	for _, seg := range segments {
+		if len(cur) > 0 && seg.start.Sub(cur[len(cur)-1].end) > sleepSessionGap {
+			flush()
+		}
+		cur = append(cur, seg)
+	}
+	flush()
+
+	return sessions
+}
+
+// QuerySleepDailyTotal returns nightly sleep totals, one row per night that actually
+// has data. Only Asleep stages count (Core, Deep, REM, Unspecified); InBed and Awake
+// are excluded.
+//
+// Segments are clustered into whole sessions before any date is assigned to them, so
+// a single night is never cut in half by a clock boundary. Nights with no recorded
+// sleep are omitted entirely rather than reported as zero: "did not sleep" and "did
+// not wear the watch" are different facts. Naps are reported in their own column and
+// are never folded into the night's hours.
 func (db *DB) QuerySleepDailyTotal(params QueryParams) ([]map[string]interface{}, error) {
-	query := `SELECT date(start_date, '-6 hours') AS night,
-		ROUND(SUM((julianday(end_date) - julianday(start_date)) * 24), 1) AS hours
-		FROM sleep
-		WHERE value LIKE '%Asleep%'`
+	// A night keyed to date D can hold segments recorded on D (evening onset) or on
+	// D+1 (post-midnight onset, and any nap during the following day), so the scan
+	// window is widened past To and the results are filtered by night afterwards.
+	query := `SELECT start_date, end_date FROM sleep WHERE value LIKE '%Asleep%'`
 	var args []interface{}
 
 	if params.From != "" {
@@ -509,16 +609,10 @@ func (db *DB) QuerySleepDailyTotal(params QueryParams) ([]map[string]interface{}
 		args = append(args, params.From)
 	}
 	if params.To != "" {
-		query += " AND date(start_date, '-6 hours') <= ?"
+		query += " AND date(start_date) <= date(?, '+2 days')"
 		args = append(args, params.To)
 	}
-
-	query += " GROUP BY night ORDER BY night DESC"
-
-	if params.Limit > 0 {
-		query += " LIMIT ?"
-		args = append(args, params.Limit)
-	}
+	query += " ORDER BY start_date ASC"
 
 	rows, err := db.conn.Query(query, args...)
 	if err != nil {
@@ -526,24 +620,86 @@ func (db *DB) QuerySleepDailyTotal(params QueryParams) ([]map[string]interface{}
 	}
 	defer rows.Close()
 
-	var results []map[string]interface{}
+	var segments []sleepSession
 	for rows.Next() {
-		var night string
-		var hours float64
-		if err := rows.Scan(&night, &hours); err != nil {
-			return nil, fmt.Errorf("scanning sleep total row: %w", err)
+		var startStr, endStr string
+		if err := rows.Scan(&startStr, &endStr); err != nil {
+			return nil, fmt.Errorf("scanning sleep row: %w", err)
 		}
-		results = append(results, map[string]interface{}{
-			"night": night,
-			"hours": strconv.FormatFloat(hours, 'f', 1, 64),
-		})
+		start, err := time.Parse(sleepTimeLayout, startStr)
+		if err != nil {
+			continue
+		}
+		end, err := time.Parse(sleepTimeLayout, endStr)
+		if err != nil || !end.After(start) {
+			continue
+		}
+		segments = append(segments, sleepSession{start: start, end: end})
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 
-	if results == nil {
-		results = []map[string]interface{}{}
+	type nightTotal struct {
+		hours float64
+		naps  float64
+		onset time.Time
+		wake  time.Time
+	}
+	totals := make(map[string]*nightTotal)
+
+	for _, s := range buildSleepSessions(segments) {
+		night := s.night()
+		if params.From != "" && night < params.From[:min(len(params.From), 10)] {
+			continue
+		}
+		if params.To != "" && night > params.To[:min(len(params.To), 10)] {
+			continue
+		}
+
+		t, ok := totals[night]
+		if !ok {
+			t = &nightTotal{}
+			totals[night] = t
+		}
+		if s.isNap() {
+			t.naps += s.asleep.Hours()
+			continue
+		}
+		t.hours += s.asleep.Hours()
+		if t.onset.IsZero() || s.start.Before(t.onset) {
+			t.onset = s.start
+		}
+		if s.end.After(t.wake) {
+			t.wake = s.end
+		}
+	}
+
+	nights := make([]string, 0, len(totals))
+	for night := range totals {
+		nights = append(nights, night)
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(nights)))
+
+	if params.Limit > 0 && len(nights) > params.Limit {
+		nights = nights[:params.Limit]
+	}
+
+	results := make([]map[string]interface{}, 0, len(nights))
+	for _, night := range nights {
+		t := totals[night]
+		row := map[string]interface{}{
+			"night": night,
+			"hours": strconv.FormatFloat(t.hours, 'f', 1, 64),
+			"naps":  strconv.FormatFloat(t.naps, 'f', 1, 64),
+			"onset": "",
+			"wake":  "",
+		}
+		if !t.onset.IsZero() {
+			row["onset"] = t.onset.Format("15:04")
+			row["wake"] = t.wake.Format("15:04")
+		}
+		results = append(results, row)
 	}
 	return results, nil
 }

--- a/internal/storage/queries.go
+++ b/internal/storage/queries.go
@@ -503,12 +503,18 @@ const (
 	// and a daytime nap runs to hours.
 	sleepSessionGap = 2 * time.Hour
 
-	// napOnsetStart and napOnsetEnd bound the hours in which an onset is treated as
-	// a nap rather than the start of a night. Onset time, not duration, decides this:
-	// a 2-hour night before an early flight is still a night, and a 3-hour Sunday
-	// afternoon collapse is still a nap.
+	// napOnsetStart and napOnsetEnd bound the hours in which a session may be a nap.
+	// Onset alone cannot decide it: a bedtime of 19:15 sits inside this window and is
+	// plainly a night, not a nap. Duration alone cannot decide it either: a two-hour
+	// night before an early flight is still a night. A nap is the conjunction of both,
+	// so a session qualifies only if it begins during the day AND stays short.
 	napOnsetStart = 11
 	napOnsetEnd   = 20
+
+	// napMaxDuration is the longest a daytime session can run and still be a nap.
+	// Beyond this it is treated as a night wherever it began, because calling a
+	// six-hour block a nap loses more than mislabelling a long afternoon collapse.
+	napMaxDuration = 4 * time.Hour
 
 	// nightShift maps an onset to the night it belongs to. Any onset from noon
 	// onwards keeps its own date; any onset before noon rolls back to the previous
@@ -524,11 +530,14 @@ type sleepSession struct {
 	asleep time.Duration
 }
 
-// isNap reports whether the session began during the hours in which a person is
-// awake, which makes it a nap rather than a night.
+// isNap reports whether the session both began during the hours in which a person is
+// normally awake and stayed short enough to be a nap. Both conditions are required:
+// an early bedtime falls inside the onset window but is a night, and a short sleep at
+// 04:00 falls outside it but is also a night.
 func (s sleepSession) isNap() bool {
 	h := s.start.Hour()
-	return h >= napOnsetStart && h < napOnsetEnd
+	inDaytime := h >= napOnsetStart && h < napOnsetEnd
+	return inDaytime && s.asleep < napMaxDuration
 }
 
 // night returns the date of the night this session belongs to. A nap is attributed
@@ -690,12 +699,16 @@ func (db *DB) QuerySleepDailyTotal(params QueryParams) ([]map[string]interface{}
 		t := totals[night]
 		row := map[string]interface{}{
 			"night": night,
-			"hours": strconv.FormatFloat(t.hours, 'f', 1, 64),
 			"naps":  strconv.FormatFloat(t.naps, 'f', 1, 64),
+			// A night that holds only a nap has no recorded night sleep. Reporting
+			// 0.0 there would claim the user slept nothing, which is the same
+			// fabrication as inventing hours for an unworn watch.
+			"hours": "",
 			"onset": "",
 			"wake":  "",
 		}
 		if !t.onset.IsZero() {
+			row["hours"] = strconv.FormatFloat(t.hours, 'f', 1, 64)
 			row["onset"] = t.onset.Format("15:04")
 			row["wake"] = t.wake.Format("15:04")
 		}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1037,6 +1037,126 @@ func TestQuerySleepDailyTotal_MultipleNights(t *testing.T) {
 	}
 }
 
+// A late sleeper who is still asleep past any fixed hour boundary must not have that
+// one night cut in two and filed under two dates. This is issue #17: a 6 AM boundary
+// split a 01:49 -> 08:30 night into a phantom "previous night" and a truncated one.
+func TestQuerySleepDailyTotal_LateSleeperNightNotSplit(t *testing.T) {
+	db := tempDB(t)
+	insertSleepRows(t, db, [][]any{
+		// One unbroken night: asleep 01:49, awake 08:30. Straddles 06:00.
+		{"Watch", "2024-01-02 01:49:00", "2024-01-02 05:49:00", "HKCategoryValueSleepAnalysisAsleepCore"},
+		{"Watch", "2024-01-02 05:49:00", "2024-01-02 08:30:00", "HKCategoryValueSleepAnalysisAsleepREM"},
+	})
+
+	results, err := db.QuerySleepDailyTotal(QueryParams{Table: "sleep", Limit: 50})
+	if err != nil {
+		t.Fatalf("query error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected the night to stay whole, got %d rows: %v", len(results), results)
+	}
+	if results[0]["night"] != "2024-01-01" {
+		t.Errorf("expected night '2024-01-01' (the evening it began), got %v", results[0]["night"])
+	}
+	if results[0]["hours"] != "6.7" {
+		t.Errorf("expected the full 6.7h, got %v", results[0]["hours"])
+	}
+	if results[0]["onset"] != "01:49" || results[0]["wake"] != "08:30" {
+		t.Errorf("expected onset 01:49 / wake 08:30, got %v / %v", results[0]["onset"], results[0]["wake"])
+	}
+}
+
+// A night with no records must be absent, never fabricated. The old query invented
+// hours for nights the watch was not worn by borrowing them from adjacent sessions.
+func TestQuerySleepDailyTotal_MissingNightIsOmittedNotZero(t *testing.T) {
+	db := tempDB(t)
+	insertSleepRows(t, db, [][]any{
+		{"Watch", "2024-01-02 02:00:00", "2024-01-02 08:00:00", "HKCategoryValueSleepAnalysisAsleepCore"},
+		// Nothing at all for the night of Jan 2. Watch was off.
+		{"Watch", "2024-01-04 02:00:00", "2024-01-04 08:00:00", "HKCategoryValueSleepAnalysisAsleepCore"},
+	})
+
+	results, err := db.QuerySleepDailyTotal(QueryParams{Table: "sleep", Limit: 50})
+	if err != nil {
+		t.Fatalf("query error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected only the 2 nights with data, got %d: %v", len(results), results)
+	}
+	for _, r := range results {
+		if r["night"] == "2024-01-02" {
+			t.Errorf("night 2024-01-02 has no records and must not appear, got %v", r)
+		}
+	}
+}
+
+// A daytime nap is its own session. It must not inflate the night's hours, and it must
+// be attributed to the night that preceded it.
+func TestQuerySleepDailyTotal_NapReportedSeparately(t *testing.T) {
+	db := tempDB(t)
+	insertSleepRows(t, db, [][]any{
+		{"Watch", "2024-01-02 02:53:00", "2024-01-02 09:23:00", "HKCategoryValueSleepAnalysisAsleepCore"},
+		{"Watch", "2024-01-02 14:59:00", "2024-01-02 16:41:00", "HKCategoryValueSleepAnalysisAsleepCore"},
+	})
+
+	results, err := db.QuerySleepDailyTotal(QueryParams{Table: "sleep", Limit: 50})
+	if err != nil {
+		t.Fatalf("query error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected nap to fold onto the preceding night's row, got %d: %v", len(results), results)
+	}
+	if results[0]["night"] != "2024-01-01" {
+		t.Errorf("expected night '2024-01-01', got %v", results[0]["night"])
+	}
+	if results[0]["hours"] != "6.5" {
+		t.Errorf("nap must not inflate night hours: expected 6.5, got %v", results[0]["hours"])
+	}
+	if results[0]["naps"] != "1.7" {
+		t.Errorf("expected naps 1.7, got %v", results[0]["naps"])
+	}
+}
+
+// An evening onset stays a night even though it begins before midnight.
+func TestQuerySleepDailyTotal_EveningOnsetIsNotANap(t *testing.T) {
+	db := tempDB(t)
+	insertSleepRows(t, db, [][]any{
+		{"Watch", "2024-01-01 21:30:00", "2024-01-02 05:30:00", "HKCategoryValueSleepAnalysisAsleepCore"},
+	})
+
+	results, err := db.QuerySleepDailyTotal(QueryParams{Table: "sleep", Limit: 50})
+	if err != nil {
+		t.Fatalf("query error: %v", err)
+	}
+	if results[0]["night"] != "2024-01-01" || results[0]["hours"] != "8.0" {
+		t.Errorf("expected night 2024-01-01 with 8.0h, got %v", results[0])
+	}
+	if results[0]["naps"] != "0.0" {
+		t.Errorf("a 21:30 onset is a night, not a nap; got naps=%v", results[0]["naps"])
+	}
+}
+
+// Two sources recording the same stage must be counted once, not twice. The --total
+// flag advertises deduplicated output and a plain SUM does not deliver it.
+func TestQuerySleepDailyTotal_OverlappingSegmentsCountedOnce(t *testing.T) {
+	db := tempDB(t)
+	insertSleepRows(t, db, [][]any{
+		{"Watch", "2024-01-02 01:00:00", "2024-01-02 07:00:00", "HKCategoryValueSleepAnalysisAsleepCore"},
+		{"iPhone", "2024-01-02 01:00:00", "2024-01-02 07:00:00", "HKCategoryValueSleepAnalysisAsleepCore"},
+	})
+
+	results, err := db.QuerySleepDailyTotal(QueryParams{Table: "sleep", Limit: 50})
+	if err != nil {
+		t.Fatalf("query error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 night, got %d", len(results))
+	}
+	if results[0]["hours"] != "6.0" {
+		t.Errorf("overlapping duplicate records must count once: expected 6.0, got %v", results[0]["hours"])
+	}
+}
+
 // --to filters by night (shifted date), not raw start_date, so a session that
 // starts at 23:00 on the --to day still counts toward that night.
 func TestQuerySleepDailyTotal_ToFilterIncludesPreMidnight(t *testing.T) {

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1136,6 +1136,78 @@ func TestQuerySleepDailyTotal_EveningOnsetIsNotANap(t *testing.T) {
 	}
 }
 
+// An early bedtime begins inside the daytime onset window but is unmistakably a night.
+// Classifying on onset alone swallowed it into `naps`, filed it a day early, and blanked
+// onset/wake. Nap requires a daytime onset AND a short duration, not either alone.
+func TestQuerySleepDailyTotal_EarlyBedtimeIsNotANap(t *testing.T) {
+	db := tempDB(t)
+	insertSleepRows(t, db, [][]any{
+		{"Watch", "2024-01-01 19:15:00", "2024-01-02 03:00:00", "HKCategoryValueSleepAnalysisAsleepCore"},
+	})
+
+	results, err := db.QuerySleepDailyTotal(QueryParams{Table: "sleep", Limit: 50})
+	if err != nil {
+		t.Fatalf("query error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 night, got %d: %v", len(results), results)
+	}
+	if results[0]["night"] != "2024-01-01" {
+		t.Errorf("expected night '2024-01-01', got %v", results[0]["night"])
+	}
+	if results[0]["hours"] != "7.8" {
+		t.Errorf("a 7.8h night must not become a nap: got hours=%v naps=%v",
+			results[0]["hours"], results[0]["naps"])
+	}
+	if results[0]["naps"] != "0.0" {
+		t.Errorf("expected naps 0.0, got %v", results[0]["naps"])
+	}
+	if results[0]["onset"] != "19:15" || results[0]["wake"] != "03:00" {
+		t.Errorf("expected onset 19:15 / wake 03:00, got %v / %v", results[0]["onset"], results[0]["wake"])
+	}
+}
+
+// A long daytime session is a night wherever it began. Calling a six-hour block a nap
+// loses more than mislabelling a long afternoon collapse does.
+func TestQuerySleepDailyTotal_LongDaytimeSleepIsNotANap(t *testing.T) {
+	db := tempDB(t)
+	insertSleepRows(t, db, [][]any{
+		{"Watch", "2024-01-01 13:00:00", "2024-01-01 19:00:00", "HKCategoryValueSleepAnalysisAsleepCore"},
+	})
+
+	results, err := db.QuerySleepDailyTotal(QueryParams{Table: "sleep", Limit: 50})
+	if err != nil {
+		t.Fatalf("query error: %v", err)
+	}
+	if results[0]["hours"] != "6.0" || results[0]["naps"] != "0.0" {
+		t.Errorf("expected 6.0h of night sleep and no naps, got hours=%v naps=%v",
+			results[0]["hours"], results[0]["naps"])
+	}
+}
+
+// A night whose only session is a nap has no recorded night sleep. Reporting 0.0 there
+// would assert the user slept nothing, which is as false as inventing hours outright.
+func TestQuerySleepDailyTotal_NapOnlyNightReportsNoHours(t *testing.T) {
+	db := tempDB(t)
+	insertSleepRows(t, db, [][]any{
+		{"Watch", "2024-01-02 14:00:00", "2024-01-02 15:30:00", "HKCategoryValueSleepAnalysisAsleepCore"},
+	})
+
+	results, err := db.QuerySleepDailyTotal(QueryParams{Table: "sleep", Limit: 50})
+	if err != nil {
+		t.Fatalf("query error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(results))
+	}
+	if results[0]["hours"] != "" {
+		t.Errorf("night sleep is unknown, not zero: got hours=%q", results[0]["hours"])
+	}
+	if results[0]["naps"] != "1.5" {
+		t.Errorf("expected naps 1.5, got %v", results[0]["naps"])
+	}
+}
+
 // Two sources recording the same stage must be counted once, not twice. The --total
 // flag advertises deduplicated output and a plain SUM does not deliver it.
 func TestQuerySleepDailyTotal_OverlappingSegmentsCountedOnce(t *testing.T) {


### PR DESCRIPTION
Fixes #17.

## The bug

`QuerySleepDailyTotal` grouped sleep by `date(start_date, '-6 hours')`, which puts the night boundary at 06:00. Any segment starting after 06:00 was attributed to the current calendar day and anything before it to the previous day, so a single contiguous night that ran past 6 AM was cut in half and filed under two different dates.

The failure was quiet rather than loud. Nights where the watch was never worn came back with believable-looking hours, borrowed from the far half of a neighbouring session, and real nights came back undercounted. On my own data, a night with **zero records** reported 4.0h, and a real 5.4h night reported 1.8h. Nothing about the output looked wrong enough to question.

Before, on a week of real data:

```
HOURS  NIGHT
1.8    2026-07-13   <- actually 5.4h
5.6    2026-07-12
4.0    2026-07-11   <- no records at all for this night
3.2    2026-07-10   <- actually 5.4h
3.8    2026-07-09
4.0    2026-07-08   <- no records at all
5.0    2026-07-07
3.3    2026-07-06   <- no records at all
```

Grouping by the tool's own expression shows the tear directly. The bucket labelled `2026-07-12` spans **Jul 12 06:04 to Jul 13 06:05** — the tail of one night welded to the head of the next:

```
night        first seg            last seg              n    hrs
2026-07-11   2026-07-12 01:49:29  2026-07-12 06:02:12   16   4.0
2026-07-12   2026-07-12 06:04:12  2026-07-13 06:05:16   22   5.55
2026-07-13   2026-07-13 06:05:16  2026-07-13 08:14:38    8   1.77
```

## The fix

There is no correct hour to pick. Any fixed boundary bisects somebody's sleep: choose 6 AM and you cut a late sleeper's night, choose 11 AM and you cut the night they slept in. So the boundary is no longer the grouping primitive.

Segments are clustered into whole **sessions** first, breaking wherever the data goes quiet for more than two hours. Within a night, awake segments run to minutes; between waking and a nap, the gap runs to hours. The cut points come from where the data is actually empty rather than from the clock, so nothing is ever split. A date is then assigned **once per session**, from its onset.

Other changes that fall out of this:

- **Overlapping segments are merged before summing.** `--total` advertises deduplicated output; a plain `SUM` over segment durations does not deliver it, and would double-count if two sources ever wrote sleep for the same stage. This is the same class of bug already fixed for steps.
- **Naps are classified by onset hour, not duration**, and get their own column. Duration is the tempting rule and it is wrong in both directions: a 2-hour night before an early flight is a night, and a 3-hour Sunday afternoon collapse is a nap. A nap is attributed to the night that preceded it, so a night and the naps that follow it during the same waking day land on one row. Nap hours are never folded into the night's hours.
- **Nights with no records are omitted, never reported as zero.** "Did not sleep" and "did not wear the watch" are different facts and the output has to be able to distinguish them. Fabricating a number for an empty night was the bug's single worst property, because it is invisible on inspection.
- **Onset and wake times are exposed**, which is what makes a chronically late bedtime visible at all.
- The `--from` / `--to` filters now both apply to the computed night. Previously `--from` compared raw `start_date` while `--to` compared the shifted expression, so the two window edges did not mean the same thing.

After, same data:

```
HOURS  NAPS  NIGHT       ONSET  WAKE
5.4    0.0   2026-07-12  02:19  08:14
5.9    0.0   2026-07-11  01:49  08:30
5.4    0.0   2026-07-09  03:47  09:19
5.5    0.0   2026-07-08  02:26  08:00
6.5    1.7   2026-07-06  02:53  09:36
```

Five real nights, the three phantom nights gone, the afternoon nap in its own column, and the 2 to 4 AM onset now impossible to miss.

## Tests

Five new cases in `internal/storage/storage_test.go`, each pinning one property the old code got wrong:

- a late sleeper's night straddling 06:00 stays whole
- a night with no records is absent rather than zero
- a nap is reported separately and does not inflate the night
- an evening onset before midnight is a night, not a nap
- overlapping records from two sources count once

The six pre-existing sleep tests still pass unmodified. None of them used a wake time past 6 AM, which is why the bug survived. Full suite: 194 passing.

## Compatibility

`night` and `hours` keep their names and meaning, so existing JSON/CSV consumers keep working; `hours` simply becomes correct. `naps`, `onset` and `wake` are additive. Callers that assumed every date in a range would return a row will now see gaps where the data is genuinely missing, which is the point.
